### PR TITLE
Feature/install methods

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -67,7 +67,7 @@ Please note that `.ddmignore` files don't support spaces.
 Each configuration pack must include a sub directory named `conf` that contains
 the configuration files for the application that the configuration package is
 targeting. More information about how `ddm` installs these configuration files
-can be found under the [installation properties](#installation-properties)
+can be found under the [install properties](#install-properties)
 section.
 
 ### Install Checking 
@@ -107,7 +107,10 @@ variables mean can also be found at the end of this section.
 install_dir
     description: the directory to install the conf files to
     default: $HOME/.config/<application_name>
-    value: string
+install_method
+    desription: selects the method of installation
+    default: symlink
+    variants: symlink || copy
 ```
 
 #### Variables

--- a/ddm
+++ b/ddm
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-VERSION='0.2.3'
+VERSION='0.2.4'
 
 SH='/usr/bin/env sh'
 LN='/usr/bin/env ln -srf'
@@ -10,11 +10,11 @@ DOTFILES_GLOB='.[!.]*'
 
 IGNORED_GLOBS_FILE='.ddmignore'
 CREATED_DIRS_CACHE_FILE='.created_dirs'
-CREATED_LINKS_CACHE_FILE='.created_links'
+CREATED_FILES_CACHE_FILE='.created_files'
 
 IGNORED_GLOBS=''
 CREATED_DIRS_CACHE=''
-CREATED_LINKS_CACHE=''
+CREATED_FILES_CACHE=''
 
 RED='\e[31m'
 BOLD='\e[1m'
@@ -229,7 +229,7 @@ submodule_path_correct() {
 ##
 log_creation() {
     offset_dirs_file="$(submodule_path_correct "$CREATED_DIRS_CACHE_FILE")"
-    offset_links_file="$(submodule_path_correct "$CREATED_LINKS_CACHE_FILE")"
+    offset_links_file="$(submodule_path_correct "$CREATED_FILES_CACHE_FILE")"
 
     if [ -d "$1" ]; then
         echo "$1" >> "$offset_dirs_file" 
@@ -252,7 +252,7 @@ log_creation() {
 ##
 resolve_file_conflict() {
     if [ -e "$1" ]; then
-        if in_array "$CREATED_LINKS_CACHE" "$1"; then
+        if in_array "$CREATED_FILES_CACHE" "$1"; then
             info "skipping '""$(basename "$1")""'; already installed"
             return 1
         fi
@@ -327,14 +327,14 @@ create_dir_if_not_exists() {
 ##
 load_persistent_files() {
     created_dirs_offset="$(submodule_path_correct "$CREATED_DIRS_CACHE_FILE")"
-    created_links_offset="$(submodule_path_correct "$CREATED_LINKS_CACHE_FILE")"
+    created_links_offset="$(submodule_path_correct "$CREATED_FILES_CACHE_FILE")"
 
     if [ -e "$created_dirs_offset" ]; then
         CREATED_DIRS_CACHE="$(file_to_array "$created_dirs_offset")"
     fi
 
     if [ -e "$created_links_offset" ]; then
-        CREATED_LINKS_CACHE="$(file_to_array "$created_links_offset")"
+        CREATED_FILES_CACHE="$(file_to_array "$created_links_offset")"
     fi
 
     if [ -e "$IGNORED_GLOBS_FILE" ]; then
@@ -538,15 +538,15 @@ install() {
 ##
 uninstall() {
     # if no cache files exist we should warn the user about it and exit
-    if [ ! -f "$CREATED_LINKS_CACHE_FILE" ] && [ ! -f "$CREATED_DIRS_CACHE_FILE" ]; then
+    if [ ! -f "$CREATED_FILES_CACHE_FILE" ] && [ ! -f "$CREATED_DIRS_CACHE_FILE" ]; then
         error 'cache files do not exist; are you sure you installed?'
         return 1
     fi
 
     # remove cached created symlinks
-    if [ -f "$CREATED_LINKS_CACHE_FILE" ]; then
+    if [ -f "$CREATED_FILES_CACHE_FILE" ]; then
         # shellcheck disable=SC2013
-        for created_symlink in $(cat "$CREATED_LINKS_CACHE_FILE"); do
+        for created_symlink in $(cat "$CREATED_FILES_CACHE_FILE"); do
             if [ -e "$created_symlink" ]; then
                 info 'removing symlink "'"$created_symlink"'"'
                 rm "$created_symlink"
@@ -571,7 +571,7 @@ uninstall() {
         done
     fi
 
-    rm -f "$CREATED_DIRS_CACHE_FILE" "$CREATED_LINKS_CACHE_FILE"
+    rm -f "$CREATED_DIRS_CACHE_FILE" "$CREATED_FILES_CACHE_FILE"
 }
 
 ############################## CLI PROCESSING ##############################  

--- a/ddm
+++ b/ddm
@@ -1,11 +1,13 @@
 #!/usr/bin/env sh
 
-VERSION='0.2.6'
+VERSION='0.3.0'
 
 CP='/usr/bin/env cp -Ln'
 SH='/usr/bin/env sh'
 LN='/usr/bin/env ln -srf'
 RMDIR='rmdir --parents --ignore-fail-on-non-empty'
+
+VALID_INSTALL_METHODS='symlink copy'
 
 DOTFILES_GLOB='.[!.]*'
 
@@ -442,10 +444,24 @@ install_config() {
 
     # setup default install variables
     install_dir="$HOME""/.config/""$1"
+    install_method="symlink"
 
     if [ -x "$meta_script" ]; then
         # shellcheck disable=SC1090
         . "$meta_script"
+    fi
+
+    # check installation properties for validity
+
+    # check install directory 
+    if ! create_dir_if_not_exists "$install_dir"; then
+        return 1;
+    fi
+
+    # check install method
+    if ! in_array "$VALID_INSTALL_METHODS" "$install_method"; then
+        error "unrecognized install_method: '""$install_method""'"
+        return 1
     fi
 
     info "installing '""$1""' configurations to '""$install_dir""'"
@@ -457,18 +473,21 @@ install_config() {
         return 1
     fi
 
-    # create/check existence of install directory
-    if ! create_dir_if_not_exists "$install_dir"; then
-        return 1;
-    fi
-
-    # init var for valid configuration files
+    # var for list of conf files
     conf_files=''
 
     # normally globs don't match dotfiles - so we need two passes, once to 
     # pick up the dotfiles, another to pick up any other files
     conf_files="$(collect_file_glob "$conf_files_location" "$DOTFILES_GLOB")"
     conf_files="$conf_files""$(collect_file_glob "$conf_files_location" '*')"
+
+    # store install function for repeated use
+    install_fn=''
+    if [ "$install_method" = "symlink" ]; then
+        install_fn=logged_ln
+    elif [ "$install_method" = "copy" ]; then
+        install_fn=logged_cp
+    fi
 
     # iterate through files linking to the right location
     for to_copy in $conf_files; do
@@ -479,7 +498,7 @@ install_config() {
             continue
         fi
 
-        logged_ln "$to_copy" "$install_dir"
+        $install_fn "$to_copy" "$install_dir"
     done
 }
 
@@ -579,10 +598,10 @@ uninstall() {
     # remove cached created symlinks
     if [ -f "$CREATED_FILES_CACHE_FILE" ]; then
         # shellcheck disable=SC2013
-        for created_symlink in $(cat "$CREATED_FILES_CACHE_FILE"); do
-            if [ -e "$created_symlink" ]; then
-                info 'removing symlink "'"$created_symlink"'"'
-                rm "$created_symlink"
+        for created_file in $(cat "$CREATED_FILES_CACHE_FILE"); do
+            if [ -e "$created_file" ]; then
+                info 'removing file "'"$created_file"'"'
+                rm "$created_file"
             fi
         done
     fi

--- a/ddm
+++ b/ddm
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-VERSION='0.2.4'
+VERSION='0.2.5'
 
 SH='/usr/bin/env sh'
 LN='/usr/bin/env ln -srf'
@@ -104,6 +104,17 @@ prompt_conflict() {
 ############################## UTILITY ##############################  
 
 #################### STRING ####################  
+
+##
+# converts a string to all lowercase characters
+#
+# @1      - the string to convert to lowercase
+# @return - the string in all lowercase
+##
+to_lowercase() {
+    res="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
+    printf '%s' "$res"
+}
 
 ##
 # determines whether or not a given string starts with a substr 
@@ -580,6 +591,7 @@ uninstall() {
 [ -z "$DDM_ARGS" ] && { DDM_ARGS="$*"; export DDM_ARGS; }
 
 # if child 'import' ddm definitions from parent
+# shellcheck disable=SC2086
 [ -n "$DDM" ] && { set $DDM_ARGS; }
 
 # print usage info with no arguments 

--- a/ddm
+++ b/ddm
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
-VERSION='0.2.5'
+VERSION='0.2.6'
 
+CP='/usr/bin/env cp -Ln'
 SH='/usr/bin/env sh'
 LN='/usr/bin/env ln -srf'
 RMDIR='rmdir --parents --ignore-fail-on-non-empty'
@@ -301,9 +302,31 @@ logged_ln() {
         log_creation "$full_dest"
         return 0
     else
-        error 'cannot create symlink in '"$2" 
+        error "cannot create symlink in '""$2""'" 
         return 1
     fi 
+}
+
+##
+# copy a file to a destination and log a success
+#
+# @1      - the source path
+# @2      - the destination path
+# @return - 0 for a copy success, 1 otherwise
+##
+logged_cp() {
+    filename="$(basename "$1")"
+    full_dest="$2"'/'"$filename"
+
+    info "copying '""$1""' to '""$2"
+
+    if $CP "$1" "$2"; then
+        log_creation "$full_dest"
+        return 0
+    else
+        error "cannot copy '""$filename""'to '""$2""'"
+        return 1
+    fi
 }
 
 ##
@@ -491,15 +514,14 @@ process_submodules() {
     # exit directory of submodule
     cd '../..'
 
-    # decrement ddm after exiting
+    # decrement ddm 
     DDM=$((DDM-1))
 
+    # unset if le 0 to prevent negative DDM
+    [ "$DDM" -le 0 ] && unset DDM
+    
     # export just in case
-    if [ "$DDM" -le 0 ]; then
-        unset DDM
-    else
-        export DDM
-    fi
+    export DDM
 }
 
 ############################## SUBCOMMANDS ##############################  


### PR DESCRIPTION
Completed an implementation of variable installation methods. This is why `meta` files and parsing was created in the first place, so adding this extension wasn't too burdensome. 

However, I feel that I should note that the containing function for installation applications, which is the same function that sources and checks meta files, is becoming awfully bloated. I would love to split it into another function, but that would break my fake-conception of function-local variables... Not sure how to reconcile this without a mess.

In any case, this feature is completed but not tested at all.